### PR TITLE
Use correct case for include statements

### DIFF
--- a/library/src/main/jni/cge/common/cgeImageFilter.cpp
+++ b/library/src/main/jni/cge/common/cgeImageFilter.cpp
@@ -5,7 +5,7 @@
 *      Author: Wang Yang
 */
 
-#include "CGEImageFilter.h"
+#include "cgeImageFilter.h"
 
 CGE_UNEXPECTED_ERR_MSG
 (

--- a/library/src/main/jni/source/customFilter_0.cpp
+++ b/library/src/main/jni/source/customFilter_0.cpp
@@ -6,7 +6,7 @@
 //  Copyright © 2016年 wysaid. All rights reserved.
 //
 
-#include "CustomFilter_0.h"
+#include "customFilter_0.h"
 
 using namespace CGE;
 

--- a/library/src/main/jni/source/customFilter_N.cpp
+++ b/library/src/main/jni/source/customFilter_N.cpp
@@ -6,7 +6,7 @@
 //  Copyright © 2016年 wysaid. All rights reserved.
 //
 
-#include "CustomFilter_N.h"
+#include "customFilter_N.h"
 
 using namespace CGE;
 

--- a/library/src/main/jni/source/customFilter_N.h
+++ b/library/src/main/jni/source/customFilter_N.h
@@ -9,7 +9,7 @@
 #ifndef CustomFilter_N_h
 #define CustomFilter_N_h
 
-#include "CustomFilter_0.h"
+#include "customFilter_0.h"
 
 class CustomFilter_1 : public CGE::CGEImageFilterInterface
 {


### PR DESCRIPTION
Could not build on linux due to case sensitive file system.

This was enough for me to build w/out opencv, and ` export CGE_USE_VIDEO_MODULE=1`.

YMMV