### PR TITLE
Pre-recorded videos will now end up with correct rotation.

### DIFF
--- a/library/src/main/jni/interface/cgeFrameRecorder.cpp
+++ b/library/src/main/jni/interface/cgeFrameRecorder.cpp
@@ -353,7 +353,7 @@ namespace CGE
 		delete m_encoder;
 		m_encoder = new CGEVideoEncoderMP4();
 		m_encoder->setRecordDataFormat(CGEVideoEncoderMP4::FMT_RGBA8888);
-		if(!m_encoder->init(filename, fps, m_dstSize.width, m_dstSize.height, true, bitRate))
+		if(!m_encoder->init(filename, "0", fps, m_dstSize.width, m_dstSize.height, true, bitRate))
 		{
 			delete m_encoder;
 			m_encoder = nullptr;

--- a/library/src/main/jni/interface/cgeVideoDecoder.cpp
+++ b/library/src/main/jni/interface/cgeVideoDecoder.cpp
@@ -414,6 +414,33 @@ namespace CGE
 	{
 		return (m_context && m_context->pVideoStream) ? m_context->pFormatCtx->metadata : nullptr;
 	}
+
+    const char *CGEVideoDecodeHandler::getRotate() {
+        return extractMetadataInternal("rotate");
+    }
+
+    const char *CGEVideoDecodeHandler::extractMetadataInternal(const char* key) {
+        char* value = NULL;
+        AVFormatContext *ic = m_context->pFormatCtx;
+        AVStream *video_st = m_context->pVideoStream;
+        AVStream *audio_st = m_context->pAudioStream;
+        
+        if (!ic) {
+            return value;
+        }
+        
+        if (key) {
+            if (av_dict_get(ic->metadata, key, NULL, AV_DICT_MATCH_CASE)) {
+                value = av_dict_get(ic->metadata, key, NULL, AV_DICT_MATCH_CASE)->value;
+            } else if (audio_st && av_dict_get(audio_st->metadata, key, NULL, AV_DICT_MATCH_CASE)) {
+                value = av_dict_get(audio_st->metadata, key, NULL, AV_DICT_MATCH_CASE)->value;
+            } else if (video_st && av_dict_get(video_st->metadata, key, NULL, AV_DICT_MATCH_CASE)) {
+                value = av_dict_get(video_st->metadata, key, NULL, AV_DICT_MATCH_CASE)->value;
+            }
+        }
+        
+        return value;   
+    }
 }
 
 #endif

--- a/library/src/main/jni/interface/cgeVideoDecoder.h
+++ b/library/src/main/jni/interface/cgeVideoDecoder.h
@@ -257,6 +257,8 @@ namespace CGE
 
 		AVDictionary* getOptions();
 
+		const char *getRotate();
+
 	protected:
 		CGEVideoDecodeContext* m_context;
 		int m_width, m_height;
@@ -267,7 +269,9 @@ namespace CGE
 		double m_currentTimestamp;
 
 	private:
-		unsigned char* m_bufferPtr; //视频帧缓冲
+		unsigned char* m_bufferPtr; //视频帧缓冲\
+
+		const char* extractMetadataInternal(const char *key);
 	};
 }
 

--- a/library/src/main/jni/interface/cgeVideoEncoder.cpp
+++ b/library/src/main/jni/interface/cgeVideoEncoder.cpp
@@ -16,7 +16,7 @@
 
 
 static AVStream *addStream(AVFormatContext *oc, AVCodec **codec,
-                            enum AVCodecID codec_id, int frameRate, int width = -1, int height = -1, int bitRate = 1650000, int audioSampleRate = 44100)
+                            enum AVCodecID codec_id, int frameRate, int width = -1, int height = -1, int bitRate = 1650000, int audioSampleRate = 44100, const char *rotate = "0")
 {
     AVCodecContext *c;
     AVStream *st;
@@ -35,6 +35,8 @@ static AVStream *addStream(AVFormatContext *oc, AVCodec **codec,
     }
     st->id = oc->nb_streams-1;
     c = st->codec;
+
+    if(rotate != nullptr) av_dict_set(&st->metadata, "rotate", rotate, 0);
 
     switch ((*codec)->type) {
     case AVMEDIA_TYPE_AUDIO:
@@ -210,7 +212,7 @@ namespace CGE
 			av_free(m_audioPacketBuffer);
 	}
 
-	bool CGEVideoEncoderMP4::init(const char* filename, int fps, int width, int height, bool hasAudio, int bitRate, int audioSampleRate, AVDictionary* options)
+	bool CGEVideoEncoderMP4::init(const char* filename, const char* rotate, int fps, int width, int height, bool hasAudio, int bitRate, int audioSampleRate, AVDictionary* options)
 	{
 		m_hasAudio = hasAudio;
 
@@ -238,12 +240,12 @@ namespace CGE
 
 		if(m_context->pOutputFmt->video_codec != AV_CODEC_ID_NONE)
 		{
-			m_context->pVideoStream = addStream(m_context->pFormatCtx, &m_context->pVideoCodec, m_context->pOutputFmt->video_codec, fps, width, height, bitRate, audioSampleRate);
+			m_context->pVideoStream = addStream(m_context->pFormatCtx, &m_context->pVideoCodec, m_context->pOutputFmt->video_codec, fps, width, height, bitRate, audioSampleRate, rotate);
 		}
 
 		if(m_hasAudio && m_context->pOutputFmt->audio_codec != AV_CODEC_ID_NONE)
 		{
-			m_context->pAudioStream = addStream(m_context->pFormatCtx, &m_context->pAudioCodec, m_context->pOutputFmt->audio_codec, fps, width, height, bitRate, audioSampleRate);
+			m_context->pAudioStream = addStream(m_context->pFormatCtx, &m_context->pAudioCodec, m_context->pOutputFmt->audio_codec, fps, width, height, bitRate, audioSampleRate, rotate);
 		}
 
 		if(m_videoPacketBuffer != nullptr)

--- a/library/src/main/jni/interface/cgeVideoEncoder.h
+++ b/library/src/main/jni/interface/cgeVideoEncoder.h
@@ -53,7 +53,7 @@ namespace CGE
 			int channels; //Audio channel
 		};
 
-		bool init(const char* filename, int fps, int width, int height, bool hasAudio = true, int bitRate = 1650000, int audioSampleRate = 44100, AVDictionary* options = nullptr);
+		bool init(const char* filename, const char* rotate, int fps, int width, int height, bool hasAudio = true, int bitRate = 1650000, int audioSampleRate = 44100, AVDictionary* options = nullptr);
 
 		void setRecordDataFormat(RecordDataFormat fmt);
 

--- a/library/src/main/jni/source/cgeVideoUtils.cpp
+++ b/library/src/main/jni/source/cgeVideoUtils.cpp
@@ -171,7 +171,7 @@ namespace CGE
 #else
         AVDictionary* metaData = nullptr;
 #endif
-        if(!mp4Encoder.init(outputFilename, ENCODE_FPS, videoWidth, videoHeight, !mute, 1650000, audioSampleRate, metaData))
+        if(!mp4Encoder.init(outputFilename, decodeHandler->getRotate(), ENCODE_FPS, videoWidth, videoHeight, !mute, 1650000, audioSampleRate, metaData))
         {
             CGE_LOG_ERROR("CGEVideoEncoderMP4 - start recording failed!");
             return false;


### PR DESCRIPTION
A bunch of people were having issues with video rotation, this is a fairly simple fix for it when using CGEFFmpegNativeLibrary.generateVideoWithFilter(...).

Tested on a bunch of devices and it seems to work well so far. Only downside now is that watermarks will be rotated as well.