### PR TITLE
Make the ImageGLSurfaceView support transparency

### DIFF
--- a/cgeDemo/src/main/res/layout/activity_basic_filter_demo.xml
+++ b/cgeDemo/src/main/res/layout/activity_basic_filter_demo.xml
@@ -11,7 +11,9 @@
     <org.wysaid.view.ImageGLSurfaceView
         android:id="@+id/mainImageView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        android:layout_below="@+id/seekBar"
+        android:layout_above="@+id/horizontalScroll"/>
 
     <SeekBar
         android:id="@+id/seekBar"
@@ -22,6 +24,7 @@
         />
 
     <HorizontalScrollView
+        android:id="@+id/horizontalScroll"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true">

--- a/cgeDemo/src/main/res/layout/activity_filter_demo.xml
+++ b/cgeDemo/src/main/res/layout/activity_filter_demo.xml
@@ -11,7 +11,9 @@
     <org.wysaid.view.ImageGLSurfaceView
         android:id="@+id/mainImageView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        android:layout_below="@+id/seekBar"
+        android:layout_above="@+id/horizontalScroll"/>
 
     <SeekBar
         android:id="@+id/seekBar"
@@ -22,6 +24,7 @@
         />
 
     <HorizontalScrollView
+        android:id="@+id/horizontalScroll"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true">

--- a/library/src/main/java/org/wysaid/view/ImageGLSurfaceView.java
+++ b/library/src/main/java/org/wysaid/view/ImageGLSurfaceView.java
@@ -217,7 +217,8 @@ public class ImageGLSurfaceView extends GLSurfaceView implements Renderer {
         super(context, attrs);
 
         setEGLContextClientVersion(2);
-        setEGLConfigChooser(8, 8, 8, 8, 8, 0);
+        setZOrderOnTop(true);
+        setEGLConfigChooser(8, 8, 8, 8, 16, 0);
         getHolder().setFormat(PixelFormat.RGBA_8888);
         setRenderer(this);
         setRenderMode(RENDERMODE_WHEN_DIRTY);


### PR DESCRIPTION
Currently the ImageGLSurfaceView is drawing black pixels when the image does not fill the full view. This update makes the view transparent.

I also fixed up the layouts in the image demos so the views aren't overlapping each other.

Might resolve #302 as now you will be able to set the background color of the ImageGLSurfaceView via normal methods.

