### PR TITLE
Fix bugs caused by multiple cameras

### DIFF
--- a/library/src/main/java/org/wysaid/camera/CameraInstance.java
+++ b/library/src/main/java/org/wysaid/camera/CameraInstance.java
@@ -96,6 +96,7 @@ public class CameraInstance {
                     if (cameraInfo.facing == facing) {
                         mDefaultCameraID = i;
                         mFacing = facing;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
Devices containing multiple cameras may turn on a telephoto lens or a wide-angle lens, causing image distortion.