### PR TITLE
Support 16 KB page sizes

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,10 +19,10 @@ jobs:
         ndk-version: r26d
         link-to-sdk: true
         add-to-path: true
-    - name: set up JDK 11
+    - name: set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: gradle
     - name: Grant execute permission for gradlew

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,6 +19,8 @@ jobs:
         ndk-version: r26d
         link-to-sdk: true
         add-to-path: true
+    - name: Install Ninja
+      run: sudo apt-get install ninja-build
     - name: set up JDK 17
       uses: actions/setup-java@v3
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ objs/
 obj/
 build/
 library/.cxx/
+.kotlin/

--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ dependencies {
 
 ## Build
 
-* Options to know in `local.properties`:
-  * `usingCMakeCompile=true`: Compile the native library with CMake if set to true. (Default to false, so you can use the prebuilt libs)
-  * `usingCMakeCompileDebug=true`: Compile the native library in Debug Mode if set to true. (Default to false)
-  * `disableVideoModule=true`: Disable the video recording feature(Useful for image only scenarios). The whole jni module size will be very small. (Default to false)
+* Important options in `local.properties`:
+  * `usingCMakeCompile=true`: Set to true to compile the native library with CMake. Defaults to false, allowing the use of prebuilt libraries.
+  * `usingCMakeCompileDebug=true`: Set to true to compile the native library in Debug Mode. Defaults to false.
+  * `disableVideoModule=true`: Set to true to disable the video recording feature, which is useful for image-only scenarios. This reduces the size of the native library significantly. Defaults to false.
+  * `enable16kPageSizes=true`: Set to true to enable [16k page sizes](https://developer.android.com/guide/practices/page-sizes#16-kb-impact) for the native library, applicable only in CMake compile mode. Defaults to false.
 
 * Build with `Android Studio` and CMake: (Recommended)
   * Put `usingCMakeCompile=true` in your `local.properties`

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.2'
+        classpath 'com.android.tools.build:gradle:8.7.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -27,14 +27,14 @@ allprojects {
 ext {
     android = [
             compileSdkVersion: 30,
-            buildToolsVersion: '30.0.3',
-            minSdkVersion    : 16,
+            buildToolsVersion: '34.0.0',
+            minSdkVersion    : 21,
             targetSdkVersion : 25, // higher target version needs more storage permission request.
             versionCode      : 2,
             versionName      : "3.0.0",
             applicationId    : "org.wysaid.cgeDemo",
             appcompatX       : "1.2.0",
-            ndkVersion       : "23.1.7779620",
+            ndkVersion       : "26.3.11579264",
             cmakeVersion     : "3.22.1+",
     ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:8.7.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,6 @@ org.gradle.jvmargs+=-Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.enableJetifier=true
 android.injected.testOnly=false
-android.defaults.buildfeatures.buildconfig=true
+#android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,6 @@ org.gradle.jvmargs+=-Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.enableJetifier=true
 android.injected.testOnly=false
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jan 05 14:44:46 CST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -18,9 +18,17 @@ def deployArtifacts() {
     return gradle.ext != null && gradle.ext.has("deployArtifacts") && gradle.ext.deployArtifacts;
 }
 
+def enable16kPageSizes() {
+    return gradle.ext != null && gradle.ext.has("enable16kPageSizes") && gradle.ext.enable16kPageSizes;
+}
+
 android {
     compileSdkVersion rootProject.ext.android.compileSdkVersion
     buildToolsVersion rootProject.ext.android.buildToolsVersion
+
+    buildFeatures {
+        buildConfig true
+    }
 
     if (usingCMakeCompile()) {
         ndkVersion rootProject.ext.android.ndkVersion
@@ -35,30 +43,30 @@ android {
         if (usingCMakeCompile()) {
             externalNativeBuild {
                 cmake {
-
-                    def cmakeBuildType = "";
                     def cppExtraFlags = "";
-                    def cgeVideoModuleDef = "";
 
                     if (usingCMakeCompileDebug()) {
-                        cmakeBuildType = "-DCMAKE_BUILD_TYPE=Debug"
-                        cppExtraFlags = "-DDEBUG=1 -D_DEBUG=1 -Od -g"
+                        arguments "-DCMAKE_BUILD_TYPE=Debug"
+                        cppExtraFlags = "-DDEBUG=1 -D_DEBUG=1 -O0 -g"
                     } else {
-                        cmakeBuildType = "-DCMAKE_BUILD_TYPE=Release"
+                        arguments "-DCMAKE_BUILD_TYPE=Release"
                         cppExtraFlags = "-Os -DNDEBUG=1 -D_NDEBUG=1"
                     }
 
                     if (disableVideoModule()) {
-                        cgeVideoModuleDef = "-DCGE_USE_VIDEO_MODULE=OFF"
+                        arguments "-DCGE_USE_VIDEO_MODULE=OFF"
                     } else {
-                        cgeVideoModuleDef = "-DCGE_USE_VIDEO_MODULE=ON"
+                        arguments "-DCGE_USE_VIDEO_MODULE=ON"
+                    }
+
+                    if (enable16kPageSizes()) {
+                        arguments "-DENABLE_16K_PAGE_SIZES=ON"
                     }
 
                     arguments "-DANDROID_STL=c++_static",
                             "-DANDROID_ARM_NEON=TRUE",
                             "-DANDROID_GRADLE=ON",
-                            cmakeBuildType,
-                            cgeVideoModuleDef
+                            "-Wno-deprecated"
 
                     cFlags "-ffast-math -fPIE -fPIC -DNO_LOCALE_SUPPORT=1 -DANDROID_NDK=1 -D__STDC_CONSTANT_MACROS=1 ${cppExtraFlags}"
                     cppFlags "-ffast-math -fPIE -fPIC -DNO_LOCALE_SUPPORT=1 -DANDROID_NDK=1 -D__STDC_CONSTANT_MACROS=1 -frtti -std=c++14 -fno-exceptions -fvisibility-inlines-hidden ${cppExtraFlags}"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -135,7 +135,7 @@ if (deployArtifacts()) {
                 version = version
 
                 afterEvaluate {
-                    from components.release
+                    from components.findByName('release')
 //                artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
                 }
 
@@ -181,7 +181,7 @@ if (deployArtifacts()) {
 
     task sourcesJar(type: Jar) {
         from android.sourceSets.main.java.srcDirs
-        classifier = 'sources'
+        archiveClassifier.set('sources')
     }
 
     task javadoc(type: Javadoc) {
@@ -190,7 +190,7 @@ if (deployArtifacts()) {
     }
 
     task javadocJar(type: Jar, dependsOn: javadoc) {
-        classifier = 'javadoc'
+        archiveClassifier.set('javadoc')
         from javadoc.destinationDir
     }
 

--- a/library/src/main/jni/CMakeLists.txt
+++ b/library/src/main/jni/CMakeLists.txt
@@ -53,11 +53,8 @@ else ()
     execute_process(COMMAND find ${CMAKE_CURRENT_SOURCE_DIR}/cge -maxdepth 3 -type d OUTPUT_VARIABLE CGE_CORE_HEADER_DIR)
 endif ()
 
-message("CGE_CORE_HEADER_DIR=${CGE_CORE_HEADER_DIR}")
+message(STATUS "CGE_CORE_HEADER_DIR=${CGE_CORE_HEADER_DIR}")
 string(REGEX REPLACE "\n" ";" CGE_CORE_HEADER_DIR ${CGE_CORE_HEADER_DIR})
-
-# execute_process(COMMAND bash -c "find \"${CMAKE_CURRENT_SOURCE_DIR}/cge\" -type f -iname '*.cpp' -o -iname '*.c'" OUTPUT_VARIABLE CGE_CORE_SRC)
-# string(REGEX REPLACE "\n" ";" CGE_CORE_SRC ${CGE_CORE_SRC})
 
 file(GLOB_RECURSE CGE_CORE_SRC "${CMAKE_CURRENT_SOURCE_DIR}/cge/*.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/cge/*.c"
@@ -83,14 +80,6 @@ if (CGE_USE_VIDEO_MODULE)
 
     set(CGE_VIDEO_MODULE "ffmpeg")
     add_definitions(-DCGE_USE_FFMPEG=1)
-    # if (DEFINED ANDROID_ABI)
-    #     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ffmpeg/${ANDROID_ABI}/libffmpeg.so 
-    #               ${CMAKE_CURRENT_SOURCE_DIR}/../libs/${ANDROID_ABI}/libffmpeg.so COPYONLY)
-    #     # set_target_properties(ffmpeg PROPERTIES
-    #     #         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../libs/${ANDROID_ABI})
-    #     # set_target_properties(ffmpeg PROPERTIES
-    #     #         ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../libs/${ANDROID_ABI})
-    # endif ()
 endif ()
 
 message("CGE_USE_VIDEO_MODULE=${CGE_USE_VIDEO_MODULE}")
@@ -110,12 +99,13 @@ file(GLOB_RECURSE CGE_EXT_SRC "${CMAKE_CURRENT_SOURCE_DIR}/custom/*.cpp")
 
 add_library(CGEExt SHARED ${CGE_EXT_SRC})
 
-# if (DEFINED ANDROID_ABI)
-#     set_target_properties(CGE PROPERTIES
-#             LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../libs/${ANDROID_ABI})
-#     set_target_properties(CGEExt PROPERTIES
-#             LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../libs/${ANDROID_ABI})
-# endif ()
+target_link_options(CGE PUBLIC -fPIE -fPIC -pie -Wl,-z,relro,-z,now)
+
+if (DEFINED ENABLE_16K_PAGE_SIZES AND ENABLE_16K_PAGE_SIZES)
+    # 16KB elf:  <https://developer.android.com/guide/practices/page-sizes#cmake>
+    target_link_options(CGE PUBLIC -Wl,-z,max-page-size=16384)
+    message("ENABLE_16K_PAGE_SIZES=${ENABLE_16K_PAGE_SIZES}")
+endif ()
 
 target_link_libraries(CGE
         ${CGE_VIDEO_MODULE}

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,6 +26,10 @@ if (properties.getProperty('deployArtifacts', null) == null) {
     pFile.append('\ndeployArtifacts=false\n')
 }
 
+if (properties.getProperty('enable16kPageSizes', null) == null) {
+    pFile.append('\nenable16kPageSizes=false\n')
+}
+
 def homeDir = System.getenv('HOME')
 def mavenLocalDir = "maven_local_repo"
 
@@ -48,3 +52,4 @@ gradle.ext.usingCMakeCompileDebug = properties.getProperty("usingCMakeCompileDeb
 gradle.ext.disableVideoModule = properties.getProperty("disableVideoModule", "") == "true"
 gradle.ext.deployArtifacts = properties.getProperty("deployArtifacts", "") == "true"
 gradle.ext.localRepoDir = properties.getProperty("localRepoDir", mavenLocalDir)
+gradle.ext.enable16kPageSizes = properties.getProperty("enable16kPageSizes", "") == "true"


### PR DESCRIPTION
Follow Google's guidelines: <https://developer.android.com/guide/practices/page-sizes>

- [x] Upgrade to AGP version 8.5.1 or higher and use uncompressed shared libraries.
- [x] Update CMake files.
- [x] Upgrade Android.mk.
- [x] Add options to enable 16KB page sizes.
- ❌ Do not upgrade prebuilt libraries by default. Handle this yourself, as it may cause issues.

Issue: https://github.com/wysaid/android-gpuimage-plus/issues/536
