### PR TITLE
bugfix #540 : `immutable texture` can not be resized by glTexImage2D

### DIFF
--- a/library/src/main/jni/cge/common/cgeGLFunctions.cpp
+++ b/library/src/main/jni/cge/common/cgeGLFunctions.cpp
@@ -268,12 +268,22 @@ void TextureObject::cleanup(bool deleteTexture)
 
 bool TextureObject::resize(int w, int h, const void* buffer, GLenum format)
 {
-    if (m_texture == 0 || m_size.width != w || m_size.height != h || buffer != nullptr)
+    if (m_texture != 0 && m_size.width == w && m_size.height == h && buffer == nullptr)
     {
-        if (w == 0 || h == 0)
+        return false;
+    }
+
+    if (w == 0 || h == 0)
+    {
+        assert(0 && (void*)"TextureObject::resize must not be 0!");
+        return false;
+    }
+
+    if (m_texture == 0 || m_size.width != w || m_size.height != h)
+    {
+        if (m_texture != 0)
         {
-            assert(0 && "TextureObject::resize must not be 0!");
-            return false;
+            glDeleteTextures(1, &m_texture);
         }
 
         int channel;
@@ -297,29 +307,17 @@ bool TextureObject::resize(int w, int h, const void* buffer, GLenum format)
             break;
         }
 
-        if (m_texture == 0)
-        {
-            m_texture = cgeGenTextureWithBuffer(buffer, w, h, format, GL_UNSIGNED_BYTE, channel);
-            m_size.set(w, h);
-        }
-        else
-        {
-            glBindTexture(GL_TEXTURE_2D, m_texture);
-            glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-            if (m_size.width != w || m_size.height != h)
-            {
-                m_size.set(w, h);
-                glTexImage2D(GL_TEXTURE_2D, 0, format, w, h, 0, format, GL_UNSIGNED_BYTE, buffer);
-            }
-            else
-            {
-                glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h, format, GL_UNSIGNED_BYTE, buffer);
-            }
-        }
-
-        return true;
+        m_size.set(w, h);
+        m_texture = cgeGenTextureWithBuffer(buffer, w, h, format, GL_UNSIGNED_BYTE, channel);
     }
-    return false;
+    else
+    {
+        glBindTexture(GL_TEXTURE_2D, m_texture);
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h, format, GL_UNSIGNED_BYTE, buffer);
+    }
+
+    return true;
 }
 
 //////////////

--- a/library/src/main/jni/cge/common/cgeGLFunctions.h
+++ b/library/src/main/jni/cge/common/cgeGLFunctions.h
@@ -50,8 +50,8 @@ void cgeDisableGlobalGLContext();
 typedef void* (*CGEBufferLoadFun)(const char* sourceName, void** bufferData, GLint* w, GLint* h, CGEBufferFormat* fmt, void* arg);
 typedef bool (*CGEBufferUnloadFun)(void* arg1, void* arg2);
 
-//加载纹理回调， 注， 为了保持接口简洁性， 回调返回的纹理单元将由调用者负责释放
-//返回的纹理不应该为 glDeleteTextures 无法处理的特殊纹理类型.
+// 加载纹理回调， 注， 为了保持接口简洁性， 回调返回的纹理单元将由调用者负责释放
+// 返回的纹理不应该为 glDeleteTextures 无法处理的特殊纹理类型.
 typedef GLuint (*CGETextureLoadFun)(const char* sourceName, GLint* w, GLint* h, void* arg);
 
 // You can set a common function for loading textures

--- a/library/src/main/jni/cge/common/cgeShaderFunctions.h
+++ b/library/src/main/jni/cge/common/cgeShaderFunctions.h
@@ -224,9 +224,10 @@ protected:
     inline GLint _getUniform(GLuint programId, const char* name)
     {
         GLint uniform = glGetUniformLocation(programId, name);
-        CGE_LOG_CODE(
-            if (uniform < 0)
-                CGE_LOG_ERROR("uniform name %s does not exist!\n", name););
+#ifdef DEBUG
+        if (uniform < 0)
+            CGE_LOG_ERROR("uniform name %s does not exist!\n", name);
+#endif
         return uniform;
     }
 

--- a/library/src/main/jni/interface/cgeVideoPlayer.h
+++ b/library/src/main/jni/interface/cgeVideoPlayer.h
@@ -48,7 +48,7 @@ public:
 
     bool open(const char* filename, CGEVideoDecodeHandler::SamplingStyle s = CGEVideoDecodeHandler::ssFastBilinear);
 
-    //不同的初始化方式，不与 open 合用
+    // 不同的初始化方式，不与 open 合用
     bool initWithDecodeHandler(CGEVideoDecodeHandler*);
 
     void close();
@@ -81,15 +81,15 @@ public:
 
 protected:
     ProgramObject m_program;
-    GLuint m_texYUV[3];
-    GLint m_texYLoc, m_texULoc, m_texVLoc;
-    GLuint m_posAttribLocation;
-    GLuint m_rotLoc, m_flipScaleLoc;
-    CGEVideoDecodeHandler* m_decodeHandler;
+    GLuint m_texYUV[3]{};
+    GLint m_texYLoc = -1, m_texULoc = -1, m_texVLoc = -1;
+    GLuint m_posAttribLocation{};
+    GLuint m_rotLoc{}, m_flipScaleLoc{};
+    CGEVideoDecodeHandler* m_decodeHandler{};
 
-    GLuint m_vertexBuffer;
-    int m_videoWidth, m_videoHeight;
-    int m_linesize[3];
+    GLuint m_vertexBuffer{};
+    int m_videoWidth{}, m_videoHeight{};
+    int m_linesize[3]{};
 };
 } // namespace CGE
 


### PR DESCRIPTION
bugfix: `immutable texture` is used when creating textures, so `glTexImage2D` can not be used to change the texture size.

https://github.com/wysaid/android-gpuimage-plus/issues/540

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined image and texture update processes for more efficient and responsive media rendering.
  - Enhanced video playback handling to deliver smoother, more consistent performance during frame updates.
  - Improved error handling and logging for uniform variable checks in shader programs.
  - Updated member variable initializations in the video player class for clearer state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->