### PR TITLE
chore: add Copilot workspace instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,57 @@
+# GitHub Copilot Instructions — android-gpuimage-plus
+
+This repo is a widely-used Android GPU filter library. Prefer **small, safe, backward-compatible** changes.
+
+## Non‑negotiables (stability first)
+
+- **Do not break compatibility**: avoid changing public Java APIs, JNI method signatures, or filter rule string syntax.
+- Prefer **additive** changes (new classes/methods/filters) over refactors.
+- Keep FFmpeg/video code **fully optional** (both Java and native side guards).
+
+## Where things live (only what’s non-obvious)
+
+- Java public API / JNI front door: `library/src/main/java/org/wysaid/nativePort/`
+  - `CGENativeLibrary`, `CGEImageHandler`, `CGEFrameRenderer`, `CGEFrameRecorder`
+- Native engine: `library/src/main/jni/cge/`
+- JNI bridge (Java ↔ C++): `library/src/main/jni/interface/`
+- Extension filters (built as `libCGEExt.so`): `library/src/main/jni/custom/`
+- Prebuilt FFmpeg variants: `library/src/main/jni/ffmpeg/` and `ffmpeg-16kb/`
+- Demo app (`cgeDemo/`) is for examples; avoid coupling new library APIs to demo-only code.
+
+## Build toggles you must respect
+
+These flags come from `local.properties` (see `settings.gradle`):
+
+- `usingCMakeCompile`: build native code via CMake; otherwise use prebuilt `.so` in `library/src/main/libs/`.
+- `usingCMakeCompileDebug`: toggles Debug vs Release native build.
+- `disableVideoModule`: when true, **no FFmpeg / no recording**.
+- `enable16kPageSizes`: enables 16KB page-size linking flags and uses `ffmpeg-16kb`.
+- `deployArtifacts`: enables maven publishing tasks.
+
+Important: CMake uses recursive globs, but **ndk-build (`Android.mk`) lists sources explicitly**. If you add native files that must compile in ndk-build mode, update `Android.mk` accordingly.
+
+## Native/C++ conventions that matter here
+
+- Follow `.clang-format` (Allman braces, 4 spaces, no tabs). Keep code in `namespace CGE {}`.
+- **No C++ exceptions** (compiled with `-fno-exceptions`). Use return values and log errors.
+- Use project logging macros: `CGE_LOG_INFO`, `CGE_LOG_KEEP`, `CGE_LOG_ERROR`.
+- Inline shader strings via `CGE_SHADER_STRING_PRECISION_H()` / `CGE_SHADER_STRING_PRECISION_M()`.
+
+## Java/OpenGL thread rules (project-specific pitfalls)
+
+- For `GLSurfaceView`-based classes, do GL operations on the GL thread via `queueEvent(...)`.
+- `NativeLibraryLoader` controls native library loading order; don’t unconditionally load FFmpeg when video module is disabled.
+
+## Adding a new GPU filter / feature (minimal checklist)
+
+1. Implement the filter in `library/src/main/jni/custom/` (or `cge/filters/` if it’s core).
+2. Initialize shaders/uniforms in `init()`; handle compile/link failures without crashing.
+3. Ensure GL resources are released (programs/textures/FBOs) along the existing lifecycle.
+4. If the feature is exposed to Java, add/update JNI wrappers under `library/src/main/jni/interface/` and keep signatures stable.
+5. If it should be reachable from rule strings, update the parsing/registration in the native engine (don’t change existing syntax).
+6. Keep FFmpeg/video-dependent logic behind `disableVideoModule` / `CGE_USE_VIDEO_MODULE` guards.
+
+## Communication & docs
+
+- Use **English** for code comments, commit messages, and PR descriptions.
+- Don’t add new “how to build” tutorials here—put long-form docs in `README.md` (this file should stay short).

--- a/.github/instructions/cpp.instructions.md
+++ b/.github/instructions/cpp.instructions.md
@@ -1,0 +1,17 @@
+---
+description: "Use when editing C++ native code. Covers CGE engine conventions, shader patterns, memory safety, and OpenGL ES resource management."
+applyTo:
+  - "library/src/main/jni/cge/**/*.{cpp,h,c}"
+  - "library/src/main/jni/custom/**/*.{cpp,h,c}"
+  - "library/src/main/jni/interface/**/*.{cpp,h,c}"
+---
+
+# C++ / Native Layer
+
+- Follow `.clang-format` (Allman braces, 4 spaces). All code in `namespace CGE {}`.
+- No C++ exceptions (`-fno-exceptions`). Return error codes; never `throw`.
+- Logging: `CGE_LOG_INFO` / `CGE_LOG_ERROR` / `CGE_LOG_KEEP` — never raw `__android_log_print`.
+- Inline GLSL via `CGE_SHADER_STRING_PRECISION_H()` / `CGE_SHADER_STRING_PRECISION_M()`.
+- GL resources (programs, textures, FBOs) must be released along the handler lifecycle; shader compile failures must be logged, not crash.
+- FFmpeg-dependent code: guard with `#ifdef CGE_USE_VIDEO_MODULE`.
+- When adding source files: CMake uses `GLOB_RECURSE` (auto-picks up), but `Android.mk` lists files **explicitly** — update both.

--- a/.github/instructions/java.instructions.md
+++ b/.github/instructions/java.instructions.md
@@ -1,0 +1,13 @@
+---
+description: "Use when editing Java Android library or demo code. Covers GL thread safety and native interop patterns."
+applyTo:
+  - "library/src/main/java/**/*.java"
+  - "cgeDemo/src/main/java/**/*.java"
+---
+
+# Java / Android Layer
+
+- GL operations in `GLSurfaceView` subclasses **must** run on the GL thread via `queueEvent(...)`.
+- Native methods are declared `native` and loaded through `NativeLibraryLoader` — don't add direct `System.loadLibrary` calls.
+- Don't unconditionally reference FFmpeg classes; check `BuildConfig.CGE_USE_VIDEO_MODULE` first.
+- Public API in `org.wysaid.nativePort.*` is consumed by external users — **do not change signatures**.

--- a/.github/instructions/jni-bridge.instructions.md
+++ b/.github/instructions/jni-bridge.instructions.md
@@ -1,0 +1,13 @@
+---
+description: "Use when working on JNI bridge code between Java and C++. Covers JNI safety, signature stability, and the interface/ directory conventions."
+applyTo: "library/src/main/jni/interface/**"
+---
+
+# JNI Bridge Layer (`interface/`)
+
+- JNI function names follow `Java_org_wysaid_nativePort_<Class>_<method>`.
+- Always validate JNI params (null bitmap, null env, invalid handler pointer) before dereferencing.
+- C++ side uses `CGEImageHandlerAndroid` — obtain via `reinterpret_cast` from the Java `long` handle; **never** store JNI local refs across calls.
+- `NativeLibraryLoader` loads `libCGE.so` → `libCGEExt.so` → optionally `libffmpeg.so`. Respect this ordering.
+- Video/recording wrappers (`cgeFrameRecorder*`, `cgeVideoEncoder*`) must compile-guard with `CGE_USE_VIDEO_MODULE`.
+- Any new JNI method needs a corresponding Java `native` declaration in `org.wysaid.nativePort.*` — keep signatures stable for binary compatibility.


### PR DESCRIPTION
## Summary
Add lightweight GitHub Copilot workspace guidance for this repo, focused on stability/compatibility and project-specific pitfalls.

## Changes
- Add `.github/copilot-instructions.md` (short, repo-specific red lines + key build toggles)
- Add file-scoped instructions under `.github/instructions/` for:
  - C++ native layer (`cge/`, `custom/`, `interface/`)
  - Java Android layer (library + demo)
  - JNI bridge (`library/src/main/jni/interface/`)

## Notes
- No production/library behavior changes (docs/config only).
- `applyTo` globs are scoped to avoid third-party FFmpeg trees.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive development and contribution guidelines covering C++ conventions, Java/Android threading standards, JNI bridge integration patterns, API stability requirements, and repository structure to standardize development practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->